### PR TITLE
Add id parameter to UpdateListMember

### DIFF
--- a/src/ZfrMailChimp/Client/ServiceDescription/MailChimp-2.0.php
+++ b/src/ZfrMailChimp/Client/ServiceDescription/MailChimp-2.0.php
@@ -1478,6 +1478,12 @@ return array(
                     'sentAs'      => 'apikey',
                     'required'    => true
                 ),
+                'id' => array(
+                    'description' => 'The list id to connect to',
+                    'location'    => 'json',
+                    'type'        => 'string',
+                    'required'    => true
+                ),
                 'email' => array(
                     'description' => 'An array containing data about the email',
                     'location'    => 'json',


### PR DESCRIPTION
The UpdateListMember command is missing the list id parameter, see http://apidocs.mailchimp.com/api/2.0/lists/update-member.php
