### PR TITLE
GetListMergeVars takes id param as an array.

### DIFF
--- a/src/ZfrMailChimp/Client/ServiceDescription/MailChimp-2.0.php
+++ b/src/ZfrMailChimp/Client/ServiceDescription/MailChimp-2.0.php
@@ -1091,7 +1091,7 @@ return array(
                 'id' => array(
                     'description' => 'The list id to retrieve merge vars for',
                     'location'    => 'json',
-                    'type'        => 'string',
+                    'type'        => 'array',
                     'required'    => true
                 ),
             )


### PR DESCRIPTION
See api docs for list merge vars, Id parameter expects an array.

http://apidocs.mailchimp.com/api/2.0/lists/merge-vars.php
