### PR TITLE
add AddStaticListSegment to service description

### DIFF
--- a/src/ZfrMailChimp/Client/MailChimpClient.php
+++ b/src/ZfrMailChimp/Client/MailChimpClient.php
@@ -49,8 +49,8 @@ use ZfrMailChimp\Client\Listener\ErrorHandlerListener;
  * @method array addInterestGrouping(array $args = array()) {@command MailChimp AddInterestGrouping}
  * @method array addListMergeVar(array $args = array()) {@command MailChimp AddListMergeVar}
  * @method array addListSegment(array $args = array()) {@command MailChimp AddListSegment}
- * @method array addStaticListSegment(array $args = array()) {@command MailChimp AddStaticListSegment}
  * @method array addListWebhook(array $args = array()) {@command MailChimp AddListWebhook}
+ * @method array addStaticListSegment(array $args = array()) {@command MailChimp AddStaticListSegment}
  * @method array addStaticSegmentMembers(array $args = array()) {@command MailChimp AddStaticSegmentMembers}
  * @method array batchSubscribe(array $args = array()) {@command MailChimp BatchSubscribe}
  * @method array batchUnsubscribe(array $args = array()) {@command MailChimp BatchUnsubscribe}

--- a/src/ZfrMailChimp/Client/ServiceDescription/MailChimp-2.0.php
+++ b/src/ZfrMailChimp/Client/ServiceDescription/MailChimp-2.0.php
@@ -637,34 +637,6 @@ return array(
             )
         ),
 
-        'AddStaticListSegment' => array(
-            'httpMethod'       => 'POST',
-            'uri'              => 'lists/static-segment-add.json',
-            'summary'          => 'Save a static segment against a list',
-            'documentationUrl' => 'http://apidocs.mailchimp.com/api/2.0/lists/static-segment-add.php',
-            'parameters'       => array(
-                'api_key'  => array(
-                    'description' => 'MailChimp API key',
-                    'location'    => 'json',
-                    'type'        => 'string',
-                    'sentAs'      => 'apikey',
-                    'required'    => true
-                ),
-                'id' => array(
-                    'description' => 'The list id to connect to',
-                    'location'    => 'json',
-                    'type'        => 'string',
-                    'required'    => true
-                ),
-                'name' => array(
-                    'description' => 'Name for the new segment',
-                    'location'    => 'json',
-                    'type'        => 'string',
-                    'required'    => false
-                )
-            )
-        ),
-
         'AddListWebhook' => array(
             'httpMethod'       => 'POST',
             'uri'              => 'lists/webhook-add.json',
@@ -705,6 +677,34 @@ return array(
             )
         ),
 
+        'AddStaticListSegment' => array(
+            'httpMethod'       => 'POST',
+            'uri'              => 'lists/static-segment-add.json',
+            'summary'          => 'Save a static segment against a list',
+            'documentationUrl' => 'http://apidocs.mailchimp.com/api/2.0/lists/static-segment-add.php',
+            'parameters'       => array(
+                'api_key'  => array(
+                    'description' => 'MailChimp API key',
+                    'location'    => 'json',
+                    'type'        => 'string',
+                    'sentAs'      => 'apikey',
+                    'required'    => true
+                ),
+                'id' => array(
+                    'description' => 'The list id to connect to',
+                    'location'    => 'json',
+                    'type'        => 'string',
+                    'required'    => true
+                ),
+                'name' => array(
+                    'description' => 'Name for the new segment',
+                    'location'    => 'json',
+                    'type'        => 'string',
+                    'required'    => false
+                )
+            )
+        ),
+        
         'AddStaticSegmentMembers' => array(
             'httpMethod'       => 'POST',
             'uri'              => 'lists/static-segment-members-add.json',


### PR DESCRIPTION
I added `addStaticListSegment` to the Service description/doc-block.
Is there a special reason zfr-mailchimp does not support `addStaticListSegment`?
A static segment can probably also be created with `addListSegment`...

Feedback appreciated.
