### PR TITLE
Fix the fatal error when the error name does not exist

### DIFF
--- a/src/ZfrMailChimp/Client/Listener/ErrorHandlerListener.php
+++ b/src/ZfrMailChimp/Client/Listener/ErrorHandlerListener.php
@@ -147,7 +147,7 @@ class ErrorHandlerListener implements EventSubscriberInterface
         }
 
         $result    = json_decode($response->getBody(), true);
-        $errorName = isset($result['name']) ? $result['name'] : 'Unknown_Exception';
+        $errorName = isset($result['name']) && array_key_exists($result['name'], $this->errorMap) ? $result['name'] : 'Unknown_Exception';
 
         throw new $this->errorMap[$errorName]($result['error'], $result['code']);
     }


### PR DESCRIPTION
Checks that the error is available in the array of errors.

If you have any questions just ask. Thankyou.
