### PR TITLE
Updated Guzzle composer dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
   ],
   "require": {
     "php": ">=5.3.3",
-    "guzzle/guzzle": "~3.5"
+    "guzzlehttp/guzzle": "~3.5"
   },
   "require-dev": {
     "phpunit/phpunit": "~3.7"


### PR DESCRIPTION
Composer warns that guzzle/guzzle is abandoned and to use guzzlehttp/guzzle instead. This one does that.